### PR TITLE
Fixes: Nuclear Science, Migrations, & Corrundum

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -10,6 +10,7 @@ require('patches.item_weight')
 require('patches.entity')
 require('patches.technology')
 require('patches.quality')
+require('patches.recipe')
 
 -- updates; overrides over other mods
 

--- a/fixes/tech_cards.lua
+++ b/fixes/tech_cards.lua
@@ -72,6 +72,7 @@ local function reformat(original_name, short_name, import_location, tech_name, i
     local i = data.raw.tool[original_name]
     i.icon = '__xy-k2so-enhancements__/icons/'..short_name..'-tech-card.png'
     i.localised_name = {'item-name.xy-'..short_name..'-tech-card'}
+    i.pictures = nil;
 
     -- Finally, change the technology to give research data recipe + change its icons and loc
     local tech_name = tech_name or original_name

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -8,6 +8,7 @@ xy-paracelsin-tech-card-endgame=(Paracelsin) Endgame techs require galvanization
 xy-mechanical-plant-more-recipes=(Paracelsin) Mechanical plant can run more recipes [color=#a6d22c](Suggested)[/color]
 xy-secretas-tech-card=[color=yellow]Fix (Secretas)[/color]: Add/replace golden tech card [color=#2cd2a9](Highly Recommended)[/color]
 xy-corrundum-tech-card=[color=yellow]Fix (Corrundum)[/color]: Add/replace electrochemical tech card [color=#2cd2a9](Highly Recommended)[/color]
+xy-corrundum-processing-unit=(Corrundum): Add "Platinum processing unit" alternative recipe
 xy-secretas-polish=(Secretas) General polishing/tweaks [color=green](Recommended)[/color]
 xy-adv-chem-plant-rebalance=(Paracelsin) Rebalance chemical plant upgrades [color=green](Recommended)[/color]
 xy-lab-recipe-changes=(Muluna, Paracelsin) Lategame lab rebalance [color=green](Recommended)[/color]
@@ -26,6 +27,7 @@ xy-item-weight=Buffs key intermediate components such as [item=kr-electronic-com
 xy-processing-unit-alt=[color=yellow]Warning: May cause minor issues to existing saves.[/color] [recipe=kr-bio-processing-circuit] takes place in the [entity=biochamber] and uses an appropriate amount of [item=advanced-circuit]. Locks the Cerys [item=processing-unit] from nitric acid to Cerys and rebalances it to K2 standards. Changes the Paracelsin [item=processing-unit] from nitric acid to re-align with other recipes, but uses one less [item=advanced-circuit].
 xy-move-lab-category=Moves all lab buildings to the science tab provided by the Science group mod. This is automatically done if your game has >10 labs. Safe to leave this setting enabled even if it does nothing.
 xy-moshine-connection-length=Increases the distance from [planet=nauvis] and [planet=vulcanus] to Moshine to 10000 and 25000 km respectively. The asteroid density is not affected.
+xy-corrundum-processing-unit=Corrundum has no on-planet method of creating [item=processing-unit], due to the lack of direct source of [item=kr-rare-metals]. As it is a T1 planet, this recipe helps ensure that if you're stranded on Corrundum, you can build a rocket from scratch.
 xy-paracelsin-tech-card=[color=orange]Warning: Fixes are highly recommended to be left enabled. Affects saves already producing galvanization science packs[/color]. This setting is left as there is another mod that adds a galvanization tech card.
 xy-paracelsin-tech-card-endgame=[color=orange]Warning: Affects endgame saves.[/color] Researches requiring [item=promethium-science-pack] also require galvanization tech card. Requires "Add/replace galvanization tech card tech card" to be enabled.
 xy-secretas-polish=[color=orange]Warning: Affects saves that have reached Secretas.[/color] Changes a lot of the recipes in the mod to be less insane and require materials from other mods & K2
@@ -80,3 +82,6 @@ xy-workshop-tech-card=Workshop tech card
 
 [entity-name]
 xy-hyper-loader=Hyper loader
+
+[recipe-name]
+platinum-processing-unit=Platinum processing unit

--- a/migrations/UPDATEME.json
+++ b/migrations/UPDATEME.json
@@ -1,0 +1,15 @@
+{
+    "recipe": [
+        ["galvanization-science-pack", "xy-galvanization-research-data"],
+        ["golden-science-pack", "xy-golden-research-data"],
+        ["electrochemical-science-pack", "xy-electrochemical-research-data"],
+        ["battlefield-science-pack", "xy-battlefield-research-data"],
+        ["slp-sun-science-pack", "xy-sun-research-data"],
+        ["biorecycling-science-pack", "xy-biorecycling-research-data"],
+        ["particle-physics-science-pack", "xy-particle-physics-research-data"],
+        ["pelagos-science-pack", "xy-decomposition-research-data"],
+        ["planetaris-compression-science-pack", "xy-compression-research-data"],
+        ["gas-manipulation-pack", "xy-gas-manipulation-research-data"],
+        ["nuclear-science-pack", "xy-nuclear-research-data"]
+    ]
+}

--- a/patches/recipe.lua
+++ b/patches/recipe.lua
@@ -1,0 +1,33 @@
+-- Corrundum - add Processing Unit Recipe (Rare Metals > Platinum)
+if mods['corrundum'] and settings.startup['xy-corrundum-processing-unit'].value then
+    local platinum_pru = table.deepcopy(data.raw["recipe"]["processing-unit"])
+    platinum_pru.name = 'platinum-processing-unit'
+    platinum_pru.main_product = 'processing-unit'
+    platinum_pru.icons = {
+        {
+            icon = "__base__/graphics/icons/processing-unit.png",
+            icon_size = 64,
+            scale = 0.65,
+            shift = { 2, 2 },
+            draw_background = true,
+        },
+        {
+            icon = "__corrundum__/graphics/icons/platinum-plate.png",
+            icon_size = 64,
+            scale = 0.45,
+            shift = { -11, -11 },
+            draw_background = true,
+        }
+    }
+    platinum_pru.category = 'electronics-with-fluid'
+    platinum_pru.enabled = false
+    platinum_pru.ingredients = {
+        {type = "item", name = "platinum-plate", amount = 3},
+        {type = "item", name = "advanced-circuit", amount = 6},
+        {type = 'fluid', name = 'sulfuric-acid', amount = 10}
+    }
+    data:extend{platinum_pru}
+    table.insert(data.raw.technology['platinum-processing'].effects, {
+        type = 'unlock-recipe', recipe = 'platinum-processing-unit'
+    })
+end

--- a/settings.lua
+++ b/settings.lua
@@ -33,6 +33,17 @@ data:extend({
 
         localised_name = {'mod-setting-name.xy-corrundum-tech-card'},
     },
+    {
+        type = 'bool-setting',
+        name = 'xy-corrundum-processing-unit',
+        setting_type = 'startup',
+        default_value = true,
+        
+        order = '2-corru',
+
+        localised_name = {'mod-setting-name.xy-corrundum-processing-unit'},
+        localised_description = {'mod-setting-description.xy-corrundum-processing-unit'}
+    },
     --- Maraxsis
     {
         type = 'bool-setting',


### PR DESCRIPTION
- Removes the `pictures` part of all flask > tech card conversions, in order to ensure mods that customise that value don't result in the flask icon still being used when the item is in-world (EG on a belt). [Source](https://mods.factorio.com/mod/xy-k2so-enhancements/discussion/6978eeb2458b84bf4dda148a)
   - One day I want to add the glow that the K2SO cards have to the rest of the cards...
- Adds in a migration for all science flask > research data conversions.
   - I'm unsure if this fixes the "nuclear science" > "particle physics tech cards" conversion the poster had in the same source above, but K2SO does this same migration for its tech cards so I figured it would be good practice to implement this anyway. Please let me know if this actually completely messes things up in a way I didn't expect.
- Adds an alternative recipe for Processing Units for Corrundum that uses Platinum instead of Rare Metals, as Rare Metals cannot be obtained on Corrundum as far as I can tell (plus, Platinum is a rare metal, this feels like it makes sense).
   - I also added a setting to allow users to turn this off if they want to import Processing Units, but given Corrundum is a T1 planet, I figured it would be ideal to ensure stranded players can rebuild to the stars from scratch.
   - I put this as a patch, but I'm unsure if it should be a patch or a fix. Don't hesitate to move it if you want (or delete it entirely if you don't like the idea of this recipe / find it redundant)

NOTE: The filename of the migrations script has been left as a placeholder with the intent of changing it to whatever the version # of the mod will be - your mod, not mine, so I'm unsure whether this would be 0.6.2 or 0.7.0.