### PR TITLE
Fixing Nitric Acid in Cerys Processing Unit recipe

### DIFF
--- a/fixes/recipe.lua
+++ b/fixes/recipe.lua
@@ -37,7 +37,7 @@ if settings.startup['xy-processing-unit-alt'].value then
         data.raw['recipe']['cerys-processing-units-from-nitric-acid'].ingredients = {
             {type = 'item', name = 'electronic-circuit', amount = 3}, 
             {type = 'item', name = 'advanced-circuit', amount = 6},
-            {type = 'fluid', name = 'nitric-acid', amount = 10},
+            {type = 'fluid', name = 'kr-nitric-acid', amount = 10},
         }
         data.raw['recipe']['cerys-processing-units-from-nitric-acid'].results = {
             {type = 'item', name = 'processing-unit', amount = 2},


### PR DESCRIPTION
The [original Cerys mod code checks if K2SO is installed](https://github.com/danielmartin0/Cerys-Moon-of-Fulgora/blob/646b00a61d4d1c0d11843d3b9af96154f8acc847/common-data-only.lua#L3-L4) and if yes then [it uses nitric acid from K2SO](https://github.com/danielmartin0/Cerys-Moon-of-Fulgora/blob/646b00a61d4d1c0d11843d3b9af96154f8acc847/prototypes/recipe/recipe.lua#L290) in all of the Cerys recipes (instead of the new/Paracelsin version of Nitric acid).

So when changing the Cerisian Processing Unit recipe we should be using the K2SO Nitric acid (to avoid a Cerys softlock as the Nitric Acid this recipe wanted before the fix cannot be made on Cerys locally).