### PR TITLE
Improve compatibility with mods like Science Spread.

### DIFF
--- a/patches/entity.lua
+++ b/patches/entity.lua
@@ -67,7 +67,7 @@ if settings.startup['xy-advanced-centrifuge-rebalance'].value and mods['advanced
     -- move the tech from matter cards down to electromagnetic cards
     -- the other adv. buildings arent locked like that
     util.tech_remove_cards('k11-advanced-centrifuge', {'kr-matter-tech-card'})
-    table.insert(data.raw.technology['k11-advanced-centrifuge'].unit.ingredients, {'electromagnetic-science-pack', 1})
+    util.tech_add_card('k11-advanced-centrifuge', 'electromagnetic-science-pack')
     util.tech_add_preqs('k11-advanced-centrifuge', {'electromagnetic-science-pack'})
     -- recipe
     local ingred1 = {type = 'item', name = 'centrifuge', amount = 4}

--- a/patches/technology.lua
+++ b/patches/technology.lua
@@ -20,15 +20,15 @@ end
 --- Tech card replacements
 if settings.startup['xy-paracelsin-tech-card'].value and mods['Paracelsin'] then
     if settings.startup['xy-paracelsin-tech-card-endgame'].value then
-        table.insert(t['kr-singularity-lab'].unit.ingredients, {'galvanization-science-pack', 1})
-        table.insert(t['kr-antimatter-ammo'].unit.ingredients, {'galvanization-science-pack', 1})
-        table.insert(t['kr-antimatter-reactor'].unit.ingredients, {'galvanization-science-pack', 1})
-        table.insert(t['kr-antimatter-reactor-equipment'].unit.ingredients, {'galvanization-science-pack', 1})
-        table.insert(t['kr-intergalactic-transceiver'].unit.ingredients, {'galvanization-science-pack', 1})
+        util.tech_add_card('kr-singularity-lab', 'galvanization-science-pack')
+        util.tech_add_card('kr-antimatter-ammo', 'galvanization-science-pack')
+        util.tech_add_card('kr-antimatter-reactor', 'galvanization-science-pack')
+        util.tech_add_card('kr-antimatter-reactor-equipment', 'galvanization-science-pack')
+        util.tech_add_card('kr-intergalactic-transceiver', 'galvanization-science-pack')
     end
 
     if settings.startup['xy-lab-recipe-changes'].value and mods['planet-muluna'] then
-        table.insert(t['cryolab'].unit.ingredients, {'galvanization-science-pack', 1})
+        util.tech_add_card('cryolab', 'galvanization-science-pack')
     end
 end
 if settings.startup['xy-adv-chem-plant-rebalance'].value and mods['Paracelsin'] then
@@ -82,15 +82,15 @@ if settings.startup['xy-secretas-tech-card'].value and mods['secretas'] then
     end
     
     if settings.startup['xy-paracelsin-tech-card'].value and mods['Paracelsin'] and not mods['outer-rim'] then
-        table.insert(t['planet-discovery-secretas'].unit.ingredients, {'galvanization-science-pack', 1})
+        util.tech_add_card('planet-discovery-secretas', 'galvanization-science-pack')
     end
 end
 --- Make K2's Adv. Tank more expensive to make you actually use the Spidertron for war purposes
 if settings.startup['xy-advanced-tank-expensive-research'].value then
     t['kr-advanced-tank'].unit.count = 2500
-    table.insert(t['kr-advanced-tank'].unit.ingredients, {'metallurgic-science-pack', 1})
-    table.insert(t['kr-advanced-tank'].unit.ingredients, {'agricultural-science-pack', 1})
-    table.insert(t['kr-advanced-tank'].unit.ingredients, {'electromagnetic-science-pack', 1})
+    util.tech_add_card('kr-advanced-tank', 'metallurgic-science-pack')
+    util.tech_add_card('kr-advanced-tank', 'agricultural-science-pack')
+    util.tech_add_card('kr-advanced-tank', 'electromagnetic-science-pack')
     add_preqs('kr-advanced-tank', {'metallurgic-science-pack','agricultural-science-pack','electromagnetic-science-pack'})
 end
 --- Wipe out early tech cards in mid-late technologies

--- a/util/util.lua
+++ b/util/util.lua
@@ -37,6 +37,23 @@ local function remove_cards(tech, cards_to_remove) -- Should be used before add_
 end
 utils.tech_remove_cards = remove_cards
 
+local function add_card(tech, card_to_add)
+    local tech_prototype = t[tech]
+    if (not tech_prototype) then
+        log(tech..' - Tech does not exist!')
+        return
+    end
+
+    for _, ingredient in ipairs(tech_prototype.unit.ingredients) do
+        if (ingredient[1] == card_to_add) then
+            return
+        end
+    end
+
+    table.insert(tech_prototype.unit.ingredients, {card_to_add, 1})
+end
+utils.tech_add_card = add_card
+
 local function order_from_index(list, prototype, lead)
     local lead = lead or 'z'
     for index,item in pairs(list) do


### PR DESCRIPTION
Adds a simple utility function that guards against adding duplicate technology ingredients. Changes existing code to make use of this new utility function.

This restores compatibility with the Outer Rim mod. Fixes #17 